### PR TITLE
Add builder for creating TaskPool and add examples

### DIFF
--- a/examples/busy_behavior.rs
+++ b/examples/busy_behavior.rs
@@ -1,11 +1,11 @@
-use smalltask::TaskPoolBuilder;
+use smalltask::TaskPool;
 
 // This sample demonstrates creating a thread pool with 4 tasks and spawning 40 tasks that spin
 // for 100ms. It's expected to take about a second to run (assuming the machine has >= 4 logical
 // cores)
 
 fn main() {
-    let pool = TaskPoolBuilder::default()
+    let pool = TaskPool::build()
         .thread_name("Busy Behavior ThreadPool".to_string())
         .num_threads(4)
         .build();

--- a/examples/busy_behavior.rs
+++ b/examples/busy_behavior.rs
@@ -1,0 +1,33 @@
+use smalltask::TaskPoolBuilder;
+
+// This sample demonstrates creating a thread pool with 4 tasks and spawning 40 tasks that spin
+// for 100ms. It's expected to take about a second to run (assuming the machine has >= 4 logical
+// cores)
+
+fn main() {
+    let pool = TaskPoolBuilder::default()
+        .thread_name("Busy Behavior ThreadPool".to_string())
+        .num_threads(4)
+        .build();
+
+    let t0 = std::time::Instant::now();
+    pool.scope(|s| {
+        for i in 0..40 {
+            s.spawn(async move {
+                let now = std::time::Instant::now();
+                while std::time::Instant::now() - now < std::time::Duration::from_millis(100) {
+                    // spin, simulating work being done
+                }
+
+                println!(
+                    "Thread {:?} index {} finished",
+                    std::thread::current().id(),
+                    i
+                );
+            })
+        }
+    });
+
+    let t1 = std::time::Instant::now();
+    println!("all tasks finished in {} secs", (t1 - t0).as_secs_f32());
+}

--- a/examples/idle_behavior.rs
+++ b/examples/idle_behavior.rs
@@ -1,0 +1,31 @@
+use smalltask::TaskPoolBuilder;
+
+// This sample demonstrates a thread pool with one thread per logical core and only one task
+// spinning. Other than the one thread, the system should remain idle, demonstrating good behavior
+// for small workloads.
+
+fn main() {
+    let pool = TaskPoolBuilder::default()
+        .thread_name("Idle Behavior ThreadPool".to_string())
+        .build();
+
+    pool.scope(|s| {
+        for i in 0..1 {
+            s.spawn(async move {
+                println!("Blocking for 10 seconds");
+                let now = std::time::Instant::now();
+                while std::time::Instant::now() - now < std::time::Duration::from_millis(10000) {
+                    // spin, simulating work being done
+                }
+
+                println!(
+                    "Thread {:?} index {} finished",
+                    std::thread::current().id(),
+                    i
+                );
+            })
+        }
+    });
+
+    println!("all tasks finished");
+}

--- a/examples/idle_behavior.rs
+++ b/examples/idle_behavior.rs
@@ -1,11 +1,11 @@
-use smalltask::TaskPoolBuilder;
+use smalltask::TaskPool;
 
 // This sample demonstrates a thread pool with one thread per logical core and only one task
 // spinning. Other than the one thread, the system should remain idle, demonstrating good behavior
 // for small workloads.
 
 fn main() {
-    let pool = TaskPoolBuilder::default()
+    let pool = TaskPool::build()
         .thread_name("Idle Behavior ThreadPool".to_string())
         .build();
 


### PR DESCRIPTION
Set up a builder for constructing the TaskPool with customizable thread count, stack size, and thread name. Add a couple examples to demonstrate busy and idle workloads.