### PR TITLE
A few more usability edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # small-task
 
+A refreshingly simple task executor for games in Rust, designed for bevy. :)
+
 This is a simple threadpool with minimal dependencies. The main usecase is a scoped fork-join, i.e. spawning tasks from
 a single thread and having that thread await the completion of those tasks. This is intended specifically for 
 [`bevy`][bevy] as a lighter alternative to [`rayon`][rayon] for this specific usecase. There are also utilities for

--- a/examples/busy_behavior.rs
+++ b/examples/busy_behavior.rs
@@ -5,7 +5,7 @@ use smalltask::TaskPool;
 // cores)
 
 fn main() {
-    let pool = TaskPool::build()
+    let pool = TaskPool::builder()
         .thread_name("Busy Behavior ThreadPool".to_string())
         .num_threads(4)
         .build();

--- a/examples/idle_behavior.rs
+++ b/examples/idle_behavior.rs
@@ -5,7 +5,7 @@ use smalltask::TaskPool;
 // for small workloads.
 
 fn main() {
-    let pool = TaskPool::build()
+    let pool = TaskPool::builder()
         .thread_name("Idle Behavior ThreadPool".to_string())
         .build();
 

--- a/examples/slice.rs
+++ b/examples/slice.rs
@@ -1,0 +1,26 @@
+use smalltask::ParallelSlice;
+use smalltask::TaskPool;
+
+// This example demonstrates how to parallel iterate a slice of data in chunks
+
+fn main() {
+    let messages: Vec<_> = (0..100).collect();
+
+    let task_pool = TaskPool::builder().build();
+
+    let outputs = messages.par_chunk_map(&task_pool, 10, |values| {
+        let mut sum = 0;
+        for value in values {
+            println!(
+                "Processing value {} on thread {:?}",
+                value,
+                std::thread::current().id()
+            );
+            sum += value;
+        }
+
+        sum
+    });
+
+    println!("sums: {:?}", outputs);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use multitask::{Executor, Task};
 use parking::Unparker;
 use std::{
     fmt::{self, Debug},
@@ -15,6 +14,9 @@ use std::{
 mod slice;
 pub use slice::ParallelSlice;
 pub use slice::ParallelSliceMut;
+
+mod task;
+pub use task::Task;
 
 macro_rules! pin_mut {
     ($($x:ident),*) => { $(
@@ -79,7 +81,7 @@ impl TaskPoolBuilder {
 }
 
 pub struct TaskPool {
-    executor: Arc<Executor>,
+    executor: Arc<multitask::Executor>,
     threads: Vec<(JoinHandle<()>, Arc<Unparker>)>,
     shutdown_flag: Arc<AtomicBool>,
 }
@@ -94,7 +96,7 @@ impl TaskPool {
         stack_size: Option<usize>,
         thread_name: Option<&str>,
     ) -> Self {
-        let executor = Arc::new(Executor::new());
+        let executor = Arc::new(multitask::Executor::new());
         let shutdown_flag = Arc::new(AtomicBool::new(false));
 
         let num_threads = num_threads.unwrap_or_else(num_cpus::get);
@@ -155,8 +157,7 @@ impl TaskPool {
         F: FnOnce(&mut Scope<'scope, T>) + 'scope + Send,
         T: Send + 'static,
     {
-        // let ex = Arc::clone(&self.executor);
-        let executor: &'scope Executor = unsafe { mem::transmute(&*self.executor) };
+        let executor: &'scope multitask::Executor = unsafe { mem::transmute(&*self.executor) };
 
         let fut = async move {
             let mut scope = Scope {
@@ -183,7 +184,10 @@ impl TaskPool {
         pollster::block_on(self.executor.spawn(fut))
     }
 
-    pub fn spawn<T>(&self, future: impl Future<Output = T> + Send + 'static) -> Task<T>
+    pub fn spawn<T>(
+        &self,
+        future: impl Future<Output = T> + Send + 'static,
+    ) -> impl Future<Output = T> + Send
     where
         T: Send + 'static,
     {
@@ -226,8 +230,8 @@ impl Debug for ThreadPanicked {
 }
 
 pub struct Scope<'scope, T> {
-    executor: &'scope Executor,
-    spawned: Vec<Task<T>>,
+    executor: &'scope multitask::Executor,
+    spawned: Vec<multitask::Task<T>>,
 }
 
 impl<'scope, T: Send + 'static> Scope<'scope, T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ use std::{
 };
 
 mod slice;
+pub use slice::ParallelSlice;
+pub use slice::ParallelSliceMut;
 
 macro_rules! pin_mut {
     ($($x:ident),*) => { $(
@@ -83,7 +85,7 @@ pub struct TaskPool {
 }
 
 impl TaskPool {
-    pub fn build() -> TaskPoolBuilder {
+    pub fn builder() -> TaskPoolBuilder {
         TaskPoolBuilder::new()
     }
 
@@ -179,6 +181,13 @@ impl TaskPool {
             unsafe { mem::transmute(fut as Pin<&mut (dyn Future<Output = Vec<T>> + Send)>) };
 
         pollster::block_on(self.executor.spawn(fut))
+    }
+
+    pub fn spawn<T>(&self, future: impl Future<Output = T> + Send + 'static) -> Task<T>
+    where
+        T: Send + 'static,
+    {
+        self.executor.spawn(future)
     }
 
     pub fn shutdown(self) -> Result<(), ThreadPanicked> {

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,43 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Wraps `multitask::Task`, a spawned future.
+///
+/// Tasks are also futures themselves and yield the output of the spawned future.
+///
+/// When a task is dropped, its gets canceled and won't be polled again. To cancel a task a bit
+/// more gracefully and wait until it stops running, use the [`cancel()`][Task::cancel()] method.
+///
+/// Tasks that panic get immediately canceled. Awaiting a canceled task also causes a panic.
+/// Wraps multitask::Task
+pub struct Task<T>(multitask::Task<T>);
+
+impl<T> Task<T> {
+    /// Detaches the task to let it keep running in the background. See `multitask::Task::detach`
+    pub fn detach(self) {
+        self.0.detach();
+    }
+
+    /// Cancels the task and waits for it to stop running.
+    ///
+    /// Returns the task's output if it was completed just before it got canceled, or [`None`] if
+    /// it didn't complete.
+    ///
+    /// While it's possible to simply drop the [`Task`] to cancel it, this is a cleaner way of
+    /// canceling because it also waits for the task to stop running.
+    ///
+    /// See `multitask::Task::cancel`
+    pub async fn cancel(self) -> Option<T> {
+        self.0.cancel().await
+    }
+}
+
+impl<T> Future for Task<T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Safe because Task is pinned and contains multitask::Task by value
+        unsafe { self.map_unchecked_mut(|x| &mut x.0).poll(cx) }
+    }
+}


### PR DESCRIPTION
Make ParallelSlice and ParallelSliceMut public and add example using it
Add spawn public function to pass raw futures through to the executor
Rename TaskPool::build to TaskPool::builder because TaskPool::build().build() is kind of awkward :)